### PR TITLE
feat(body) added an option "skip_large_bodies"

### DIFF
--- a/kong/plugins/liamp/handler.lua
+++ b/kong/plugins/liamp/handler.lua
@@ -200,7 +200,7 @@ function AWSLambdaHandler:access(conf)
   local upstream_body = new_tab(0, 6)
 
   if conf.awsgateway_compatible then
-    upstream_body = aws_serializer()
+    upstream_body = aws_serializer(ngx.ctx, conf)
 
   elseif conf.forward_request_body or
          conf.forward_request_headers or

--- a/kong/plugins/liamp/schema.lua
+++ b/kong/plugins/liamp/schema.lua
@@ -114,6 +114,10 @@ return {
     proxy_url = {
       type = "string"
     },
+    skip_large_bodies = {
+      type = "boolean",
+      default = true,
+    },
   },
   self_check = function(schema, plugin_t, dao, is_update)
     if (plugin_t.aws_key or "") == "" then


### PR DESCRIPTION
The option allows to read files that were cached on disk (so really large files). The option
defaults to "true".

Turning this on might consume a lot of memory, so be very careful