### PR TITLE
perf(*) implement keepalive for proxy and ssl based connections

### DIFF
--- a/.pongorc
+++ b/.pongorc
@@ -1,0 +1,4 @@
+--postgres
+--cassandra
+--squid
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,56 +1,44 @@
-dist: trusty
-sudo: required
+dist: bionic
 
-language: java
-
-jdk:
-  - oraclejdk8
-
-notifications:
-  email: false
-
-addons:
-  postgresql: "9.5"
-  apt:
-    packages:
-      - net-tools
-      - libpcre3-dev
-      - build-essential
-
-services:
-  - docker
+jobs:
+  include:
+  - name: Enterprise 1.3.0.x
+    env: KONG_VERSION=1.3.0.x
+  - name: Enterprise 1.5.0.x
+    env: KONG_VERSION=1.5.0.x
+  - name: Kong CE 1.3.x
+    env: KONG_VERSION=1.3.x
+  - name: Kong CE 1.5.x
+    env: KONG_VERSION=1.5.x
+  - name: Kong CE 2.0.x
+    env: KONG_VERSION=2.0.x
+  - name: Nightly EE-master
+    env: KONG_VERSION=nightly-ee POSTGRES=latest CASSANDRA=latest
+  #- name: Nightly CE-master
+  #  env: KONG_VERSION=nightly POSTGRES=latest CASSANDRA=latest
 
 env:
   global:
-    - CASSANDRA_BASE=2.2.12
-    - CASSANDRA_LATEST=3.9
-    - KONG_REPOSITORY=kong
-    - KONG_TAG=next
-    - DOWNLOAD_CACHE=$HOME/download-cache
-    - INSTALL_CACHE=$HOME/install-cache
-    - DOWNLOAD_ROOT=$HOME/download-root
-    - BUSTED_ARGS="-o gtest -v --exclude-tags=flaky,ipv6"
-    - PLUGIN_NAME=aws-lambda
-    - KONG_PLUGINS=bundled,$PLUGIN_NAME
-    - KONG_TEST_PLUGINS=$KONG_PLUGINS
-    - TEST_FILE_PATH=$TRAVIS_BUILD_DIR/spec
-  matrix:
-    # This one runs both postgres and cassandra_base
-    - CASSANDRA=$CASSANDRA_BASE
-    - CASSANDRA=$CASSANDRA_LATEST
+  # for Enterprise images
+  - BINTRAY_USERNAME=kong-automation@kong
+  - BINTRAY_REPO=kong
+  - secure: XRJMsixYJLZZtQMrIQCBEgI16Qf/lMh/66/MRTpPqPRg/+kmSLPWq8/ZSwCdHOCsHr3iUi3z6XLF1FABMIPRH3R4fvwJIiLLjbR3D6X+16lKA864yL0+Y5Cp8rD6oo9UjeTligGV1xqwlufzVD5tv50NXqMmxSclGTWPc3BUHZMaiFd9kKnyR/rAc6Yy1HswaaHFbjmmnygQ/OOG3VhnfgylMsKkXkTFJTQxIYqMnV3rqk0rAaSGpLyM+A7CFOEwqgJ43Ywl4f2bCyKrikolbQvWLFL9SNSFJzdz7sMpind8JWh3+xEjCZoGQvwp48CIlb4GulTiTC/e3K6tC70M1qKMfkW360NVkipXE7N++/jKpwntE0O2FBU+dIuUv2P//DU5KBo79BMbPY1xGdzc3WpvCK7i5xt3OTtGPKQ3KTQb/ZWM7kWvqmoh7Vw/qyIXRH9OUlQu0opEaa0aqCBuQXjsoEgoDX+OLUXzuq1A1qAIq5cuQaHQfEn2FFyGkWgcvkl4KoRLWateV1PwMTccQZ2ohYDpEW08kZrrPei32pBGVO+Bp9OBjJ2gfTuTRvZHsvc6wJlrohAXs4oZBkEuXJb9SpWzQuzibt0XvJ1srevZNmaQTF1kFI5867FZdrxgv6MTQ265ccDXmEH75+fyhARozSTdAAoPpBTheiGDEoY=
+  # for Nightly Enterprise images
+  - NIGHTLY_EE_USER=tieske
+  - secure: OkR4ApVCO1Q+1Ja2rgatQ6nOK2dwuCvkbU7I0O80w7yuqp65oU2sKzZnieXkvV7FHJbmbHSH122mYqp9QwkQqwIH804T8XWPkfHZIwTm7lBseMxFMmVTQNjZvm8HDoG51FfpGs0q/AKVyd1sm410RRM3Vsz0DNBNbsZ/admzbgpJut4nzK1927Ef6xImCqqOHX5dGV3VBDHFQQcz1I74fjwVGLSpmDlIqjIrmx4X9Cz28fbw0RnrD+hQxU4dZehafbFnBXXW+lMrihwoeTdwWOXwCTaz6c+xWwBnrfBnOHEw9U4pu2fG1HvtHCEX2HxhefAsTGH12Mb+rlAkJSOaXiQVQYn19XsBE3rCQxUJfN+mLrqKnI5s7fs3G3lx7vRABwKWhxtonb7NjkVyHAULBqWqpeU69PLpIJap2QtRicRC+QYQ+Czdkg/soYusm5boVrGZT351HjhJP+09ae9CRP1fym7/9NeWIVbvdQzDQUGxMM/k0nWGFQA+CYjzBuJjxN9jISVA1aMiEKXiyMDqTaVHP3NnxDBMfQepragFg1JUNoncyDAx21/UlNJB8ObgP8mBE5lB1HaU2XFHimDCOxzjeCEmTrq1k+8PeZRGeobxAPpGzppTcM5iljeixkS7i7oNy5eIIBjmxGPhdKhWSu6ujJpLDBhTGbHFfWcxaAU=
 
 install:
-  - git clone --single-branch --branch master https://$GITHUB_TOKEN:@github.com/Kong/kong-ci.git ../kong-ci
-  - source ../kong-ci/setup_plugin_env.sh
+- git clone --single-branch https://github.com/Kong/kong-pongo ../kong-pongo
+- "../kong-pongo/pongo.sh up"
+- "../kong-pongo/pongo.sh build"
 
 script:
-  - eval $LUACHECK_CMD
-  - eval $BUSTED_CMD
+- "../kong-pongo/pongo.sh lint"
+- "../kong-pongo/pongo.sh run"
 
-cache:
-  apt: true
-  pip: true
-  directories:
-    - $DOWNLOAD_CACHE
-    - $INSTALL_CACHE
-    - $HOME/.ccm/repository
+notifications:
+  slack:
+    on_success: never
+    on_failure: always
+    rooms:
+      secure: QbZtpW6ihbx/K19d7u0TGk8b6+Uoydi/N8sL+D/BVYlMfFcVhZiOHGqMGK0F8ow5QTiXpqw/uXjgOID3zTSZsba9Qq+1YuqIPxkQ6Waw6VnCwnrR6Pw0/YGCDgxYQupDsfRUoMplJdAvwbpBYktJK/0Wy+45hHu8G9DbeiVfOqMLtbDo3JLhnrjBM3Yoxl0wwroQj8R47yfPBqHD9w+OaL8bWEIAHz+3AwsUSQ5H1RqmsITdmiuaRfo/WdJIVRjuRPVVDv96E34SwhjrDHlTzSC7j2RsPqAv8YHYD7Xj3lwm2OlIrfmjjM/Tk66wIMwo4ohmFsDEFXFPQKUdi+qKRAYBtFnokvFdi+paZBRhhegvWwXtlHl1mtg1irgsCdeSG/4oXufcVOXij8xjBbHBgrzpY/jne3vGGQfoBjvE3JPHhh319d7XeDzcmxQSTsRVm1VR6w3j28IyRjVt8RJsHpF15C4dg9LJMIeOhUTxHGN8Nvr/Jey2c8TJSL4RIHY8Q60iWXH54gcIXmhSuBVGwT5/Exlwk6sAFdaT8b/Ge0+iF9HgngMdd7jFJnlFNIVcGgAth79nUOuGrNBOP7+J3zK63lsXwisTn5n9I3rSWY6b0f30RR3qoU4wNKro4ZcO724e3QvmXb1pftPM3xWV+xX7IUuLqTEjn3ZwLGozS9Q=

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Kong AWS Lambda plugin changelog
 
+## aws-lambda 3.3.0 unreleased
+
+- Fix: when reusing the proxy based connection do not do the handshake again.
+- revamped HTTP connect method that allows for connection reuse in scenarios
+  with a proxy and/or ssl based connections
+
 ## aws-lambda 3.2.1 3-Mar-2020
 
 - Maintenance release for CI purposes

--- a/kong-plugin-aws-lambda-3.2.1-1.rockspec
+++ b/kong-plugin-aws-lambda-3.2.1-1.rockspec
@@ -25,5 +25,6 @@ build = {
     ["kong.plugins.aws-lambda.iam-ecs-credentials"]  = "kong/plugins/aws-lambda/iam-ecs-credentials.lua",
     ["kong.plugins.aws-lambda.schema"]               = "kong/plugins/aws-lambda/schema.lua",
     ["kong.plugins.aws-lambda.v4"]                   = "kong/plugins/aws-lambda/v4.lua",
+    ["kong.plugins.aws-lambda.http.connect-better"]  = "kong/plugins/aws-lambda/http/connect-better.lua",
   }
 }

--- a/kong/plugins/aws-lambda/http/connect-better.lua
+++ b/kong/plugins/aws-lambda/http/connect-better.lua
@@ -1,0 +1,213 @@
+local ngx_re_gmatch = ngx.re.gmatch
+local ngx_re_sub = ngx.re.sub
+local ngx_re_find = ngx.re.find
+
+
+local http = require "resty.http"
+
+--[[
+A better connection function that incorporates:
+  - tcp connect
+  - ssl handshake
+  - http proxy
+Due to this it will be better at setting up a socket pool where connections can
+be kept alive.
+
+
+Call it with a single options table as follows:
+
+client:connect_better {
+  scheme = "https"      -- scheme to use, or nil for unix domain socket
+  host = "myhost.com",  -- target machine, or a unix domain socket
+  port = nil,           -- port on target machine, will default to 80/443 based on scheme
+  pool = nil,           -- connection pool name, leave blank! this function knows best!
+  pool_size = nil,      -- options as per: https://github.com/openresty/lua-nginx-module#tcpsockconnect
+  backlog = nil,
+
+  ssl = {               -- ssl will be used when either scheme = https, or when ssl is truthy
+    ctx = nil,          -- options as per: https://github.com/openresty/lua-nginx-module#tcpsocksslhandshake
+    server_name = nil,
+    ssl_verify = true,  -- defaults to true
+  },
+
+  proxy = {             -- proxy will be used only if "proxy.uri" is provided
+    uri = "http://myproxy.internal:123", -- uri of the proxy
+    authorization = nil, -- a "Proxy-Authorization" header value to be used
+    no_proxy = nil,      -- comma separated string of domains bypassing proxy
+  },
+}
+]]
+function http.connect_better(self, options)
+  local sock = self.sock
+  if not sock then
+    return nil, "not initialized"
+  end
+
+  local ok, err
+  local proxy_scheme = options.scheme -- scheme to use; http or https
+  local host = options.host -- remote host to connect to
+  local port = options.port -- remote port to connect to
+  local poolname = options.pool -- connection pool name to use
+  local pool_size = options.pool_size
+  local backlog = options.backlog
+  if proxy_scheme and not port then
+    port = (proxy_scheme == "https" and 443 or 80)
+  elseif port and not proxy_scheme then
+    return nil, "'scheme' is required when providing a port"
+  end
+
+  -- ssl settings
+  local ssl, ssl_ctx, ssl_server_name, ssl_verify
+  if proxy_scheme ~= "http" then
+    -- either https or unix domain socket
+    ssl = options.ssl
+    if type(options.ssl) == "table" then
+      ssl_ctx = ssl.ctx
+      ssl_server_name = ssl.server_name
+      ssl_verify = (ssl.verify == nil) or (not not ssl.verify) -- default to true, and force to bool
+      ssl = true
+    else
+      if ssl then
+        ssl = true
+        ssl_verify = true       -- default to true
+      else
+        ssl = false
+      end
+    end
+  else
+    -- plain http
+    ssl = false
+  end
+
+  -- proxy related settings
+  local proxy, proxy_uri, proxy_uri_t, proxy_authorization, proxy_host, proxy_port
+  proxy = options.proxy
+  if proxy and proxy.no_proxy then
+    -- Check if the no_proxy option matches this host. Implementation adapted
+    -- from lua-http library (https://github.com/daurnimator/lua-http)
+    if proxy.no_proxy == "*" then
+      -- all hosts are excluded
+      proxy = nil
+
+    else
+      local no_proxy_set = {}
+      -- wget allows domains in no_proxy list to be prefixed by "."
+      -- e.g. no_proxy=.mit.edu
+      for host_suffix in ngx_re_gmatch(proxy.no_proxy, "\\.?([^,]+)") do
+        no_proxy_set[host_suffix[1]] = true
+      end
+
+      -- From curl docs:
+      -- matched as either a domain which contains the hostname, or the
+      -- hostname itself. For example local.com would match local.com,
+      -- local.com:80, and www.local.com, but not www.notlocal.com.
+      --
+      -- Therefore, we keep stripping subdomains from the host, compare
+      -- them to the ones in the no_proxy list and continue until we find
+      -- a match or until there's only the TLD left
+      repeat
+        if no_proxy_set[host] then
+          proxy = nil
+          break
+        end
+
+        -- Strip the next level from the domain and check if that one
+        -- is on the list
+        host = ngx_re_sub(host, "^[^.]+\\.", "")
+      until not ngx_re_find(host, "\\.")
+    end
+  end
+
+  if proxy then
+    proxy_uri = proxy.uri  -- full uri to proxy (only http supported)
+    proxy_authorization = proxy.authorization -- auth to send via CONNECT
+    proxy_uri_t, err = self:parse_uri(proxy_uri)
+    if not proxy_uri_t then
+      return nil, err
+    end
+
+    local p_scheme = proxy_uri_t[1]
+    if p_scheme ~= "http" then
+        return nil, "protocol " .. p_scheme .. " not supported for proxy connections"
+    end
+    proxy_host = proxy_uri_t[2]
+    proxy_port = proxy_uri_t[3]
+  end
+
+  -- construct a poolname unique within proxy and ssl info
+  if not poolname then
+    poolname = (proxy_scheme or "")
+               .. ":" .. host
+               .. ":" .. tostring(port)
+               .. ":" .. tostring(ssl)
+               .. ":" .. (ssl_server_name or "")
+               .. ":" .. tostring(ssl_verify)
+               .. ":" .. (proxy_uri or "")
+               .. ":" .. (proxy_authorization or "")
+  end
+
+  -- do TCP level connection
+  local tcp_opts = { pool = poolname, pool_size = pool_size, backlog = backlog }
+  if proxy then
+    -- proxy based connection
+    ok, err = sock:connect(proxy_host, proxy_port, tcp_opts)
+    if not ok then
+      return nil, err
+    end
+
+    if proxy and proxy_scheme == "https" and sock:getreusedtimes() == 0 then
+      -- Make a CONNECT request to create a tunnel to the destination through
+      -- the proxy. The request-target and the Host header must be in the
+      -- authority-form of RFC 7230 Section 5.3.3. See also RFC 7231 Section
+      -- 4.3.6 for more details about the CONNECT request
+      local destination = host .. ":" .. port
+      local res, err = self:request({
+        method = "CONNECT",
+        path = destination,
+        headers = {
+          ["Host"] = destination,
+          ["Proxy-Authorization"] = proxy_authorization,
+        }
+      })
+
+      if not res then
+        return nil, err
+      end
+
+      if res.status < 200 or res.status > 299 then
+        return nil, "failed to establish a tunnel through a proxy: " .. res.status
+      end
+    end
+
+  elseif not port then
+    -- non-proxy, without port -> unix domain socket
+    ok, err = sock:connect(host, tcp_opts)
+    if not ok then
+      return nil, err
+    end
+
+  else
+    -- non-proxy, regular network tcp
+    ok, err = sock:connect(host, port, tcp_opts)
+    if not ok then
+      return nil, err
+    end
+  end
+
+  -- Now do the ssl handshake
+  if ssl and sock:getreusedtimes() == 0 then
+    local ok, err = self:ssl_handshake(ssl_ctx, ssl_server_name, ssl_verify)
+    if not ok then
+      self:close()
+      return nil, err
+    end
+  end
+
+  self.host = host
+  self.port = port
+  self.keepalive = true
+
+  return true
+end
+
+return http

--- a/spec/plugins/aws-lambda/50-http-proxy_spec.lua
+++ b/spec/plugins/aws-lambda/50-http-proxy_spec.lua
@@ -100,7 +100,7 @@ end
 
 
 
-describe("#proxy", function()
+describe("#proxy #squid", function()
 
   local http
   before_each(function()
@@ -122,7 +122,7 @@ end)
 
 
 
-describe("#keepalive", function()
+describe("#keepalive #squid", function()
 
   local http
   before_each(function()

--- a/spec/plugins/aws-lambda/50-http-proxy_spec.lua
+++ b/spec/plugins/aws-lambda/50-http-proxy_spec.lua
@@ -1,0 +1,154 @@
+
+local configs = {
+  {
+    name = "plain #http",
+    scheme = "http",
+    host = "httpbin.org",
+    path = "/anything",
+  },{
+    name = "plain #https",
+    scheme = "https",
+    host = "httpbin.org",
+    path = "/anything",
+  },{
+    name = "#http via proxy",
+    scheme = "http",
+    host = "mockbin.org",
+    path = "/request",
+    proxy_url = "http://squid:3128/",
+  },{
+    name = "#https via proxy",
+    scheme = "https",
+    host = "mockbin.org",
+    path = "/request",
+    proxy_url = "http://squid:3128/",
+  },{
+    name = "#http via authenticated proxy",
+    scheme = "http",
+    host = "httpbin.org",
+    path = "/anything",
+    proxy_url = "http://squid:3128/",
+    authorization = "Basic a29uZzpraW5n",  -- base64("kong:king")
+  },{
+    name = "#https via authenticated proxy",
+    scheme = "https",
+    host = "httpbin.org",
+    path = "/anything",
+    proxy_url = "http://squid:3128/",
+    authorization = "Basic a29uZzpraW5n",  -- base64("kong:king")
+  }
+}
+
+local max_idle_timeout = 3
+
+local function make_request(http, config)
+  -- create and connect the client
+  local client = http.new()
+  local ok, err = client:connect_better {
+    scheme = config.scheme,
+    host = config.host,
+    port = config.scheme == "https" and 443 or 80,
+    ssl = config.scheme == "https" and {
+      verify = false,
+    },
+    proxy = config.proxy_url and {
+      uri = config.proxy_url,
+      authorization = config.authorization,
+    }
+  }
+  assert.is_nil(err)
+  assert.truthy(ok)
+
+  -- if proxy then path must be absolute
+  local path
+  if config.proxy_url then
+    path = config.scheme .."://" .. config.host .. (config.scheme == "https" and ":443" or ":80") .. config.path
+  else
+    path = config.path
+  end
+
+  -- make the request
+  local res, err = client:request {
+    method = "GET",
+    path = path,
+    body = nil,
+    headers = {
+      Host = config.host,
+      -- for plain http; proxy-auth must be in the headers
+      ["Proxy-Authorization"] = (config.scheme == "http" and config.authorization),
+    }
+  }
+
+  assert.is_nil(err)
+  assert.truthy(res)
+
+  -- read the body to finish socket ops
+  res.body = res:read_body()
+  local reuse = client.sock:getreusedtimes()
+
+  -- close it
+  ok, err = client:set_keepalive(max_idle_timeout)  --luacheck: ignore
+  --assert.is_nil(err)  -- result can be: 2, with error connection had to be closed
+  assert.truthy(ok)     -- resul 2 also qualifies as truthy.
+
+  -- verify http result
+  if res.status ~= 200 then assert.equal({}, res) end
+  assert.equal(200, res.status)
+  return reuse
+end
+
+
+
+
+describe("#proxy", function()
+
+  local http
+  before_each(function()
+    package.loaded["kong.plugins.aws-lambda.http.connect-better"] = nil
+    http = require "kong.plugins.aws-lambda.http.connect-better"
+  end)
+
+  lazy_teardown(function()
+    ngx.sleep(max_idle_timeout + 0.5) -- wait for keepalive to expire and all socket pools to become empty again
+  end)
+
+  for _, config in ipairs(configs) do
+    it("Make a request " .. config.name, function()
+      make_request(http, config)
+    end)
+  end
+
+end)
+
+
+
+describe("#keepalive", function()
+
+  local http
+  before_each(function()
+    package.loaded["kong.plugins.aws-lambda.http.connect-better"] = nil
+    http = require "kong.plugins.aws-lambda.http.connect-better"
+  end)
+
+  lazy_teardown(function()
+    ngx.sleep(max_idle_timeout + 0.5) -- wait for keepalive to expire and all socket pools to become empty again
+  end)
+
+  for _, config in ipairs(configs) do
+    it("Repeat a request " .. config.name, function()
+      local reuse = 0
+      local loop_size = 10
+
+      for i = 1, loop_size do
+        local conn_count = make_request(http, config)
+        reuse = math.max(reuse, conn_count)
+      end
+
+      --print(reuse)
+      assert(reuse > 0, "expected socket re-use to be > 0, but got: " .. tostring(reuse))
+      assert(reuse < loop_size, "re-use expected to be less than " .. loop_size ..
+              " but was " .. reuse .. ". So probably the socket-poolname is not unique?")
+    end)
+  end
+
+end)


### PR DESCRIPTION
This implements the keepalives to improve performance when using a proxy and/or ssl connections.

But it also adds a better test suite which includes actually testing the proxy options against a forward-proxy.

NOTE: the `better-connect.lua` file should go to the upstream `lua-resty-http` project, but is included here to make it work with older versions of Kong as well.
