### PR TITLE
fix(schema) do not validate region name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Kong AWS Lambda plugin changelog
 
+## Unreleased
+
+- Fix: do not validate region name against hardcoded list of regions
+
 ## aws-lambda 3.3.0 17-Apr-2020
 
 - Fix: when reusing the proxy based connection do not do the handshake again.

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Here's a list of all the parameters which can be used in this plugin's configura
 | `consumer_id` || The id of the Consumer which this plugin will target.
 |`config.aws_key` <br>*semi-optional* || The AWS key credential to be used when invoking the function. This value is required if `aws_secret` is defined.
 |`config.aws_secret` <br>*semi-optional* ||The AWS secret credential to be used when invoking the function. This value is required if `aws_key` is defined.
-|`config.aws_region` || The AWS region where the Lambda function is located. Regions supported are: `ap-northeast-1`, `ap-northeast-2`, `ap-south-1`, `ap-southeast-1`, `ap-southeast-2`, `ca-central-1`, `cn-north-1`, `cn-northwest-1`, `eu-central-1`, `eu-north-1`, `eu-west-1`, `eu-west-2`, `eu-west-3`, `me-south-1`, `sa-east-1`, `us-east-1`, `us-east-2`, `us-gov-west-1`, `us-west-1`, `us-west-2`.
+|`config.aws_region` || The AWS region where the Lambda function is located. The plugin *does not* attempt to validate the provided region name; an invalid region name will result in a DNS name resolution error.
 |`config.function_name` || The AWS Lambda function name to invoke.
 |`config.timeout`| `60000` | Timeout protection in milliseconds when invoking the function.
 |`config.keepalive`| `60000` | Max idle timeout in milliseconds when invoking the function.

--- a/kong/plugins/aws-lambda/schema.lua
+++ b/kong/plugins/aws-lambda/schema.lua
@@ -1,22 +1,5 @@
 local typedefs = require "kong.db.schema.typedefs"
 
-local REGIONS = {
-  "ap-northeast-1", "ap-northeast-2",
-  "ap-south-1",
-  "ap-southeast-1", "ap-southeast-2",
-  "ca-central-1",
-  "cn-north-1",
-  "cn-northwest-1",
-  "eu-central-1",
-  "eu-north-1",
-  "eu-west-1", "eu-west-2", "eu-west-3",
-  "me-south-1",
-  "sa-east-1",
-  "us-east-1", "us-east-2",
-  "us-gov-west-1",
-  "us-west-1", "us-west-2",
-}
-
 local function keyring_enabled()
   local ok, enabled = pcall(function()
     return kong.configuration.keyring_enabled
@@ -54,11 +37,7 @@ return {
           type = "string",
           encrypted = ENCRYPTED,
         } },
-        { aws_region = {
-          type = "string",
-          required = true,
-          one_of = REGIONS
-        } },
+        { aws_region = typedefs.host { required = true } },
         { function_name = {
           type = "string",
           required = true,


### PR DESCRIPTION
The plugin has historically validated the provided region name against a
list of valid region names. As AWS expands its available regions, the
plugin's schema had to be kept up-to-date. This commit removes said
validation, only requiring that a value is passed.