### PR TITLE
chore(*) release 3.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Kong AWS Lambda plugin changelog
 
-## Unreleased
+## aws-lambda 3.4.0 12-May-2020
 
+- Change `luaossl` to `lua-resty-openssl`
 - fix: do not validate region name against hardcoded list of regions
 - feat: add `host` configuration to allow for custom Lambda endpoints
 

--- a/kong-plugin-aws-lambda-3.4.0-1.rockspec
+++ b/kong-plugin-aws-lambda-3.4.0-1.rockspec
@@ -1,10 +1,10 @@
 package = "kong-plugin-aws-lambda"
-version = "3.3.0-1"
+version = "3.4.0-1"
 
 supported_platforms = {"linux", "macosx"}
 source = {
-  url = "https://github.com/Kong/kong-plugin-aws-lambda/archive/3.3.0.tar.gz",
-  dir = "kong-plugin-aws-lambda-3.3.0"
+  url = "https://github.com/Kong/kong-plugin-aws-lambda/archive/3.4.0.tar.gz",
+  dir = "kong-plugin-aws-lambda-3.4.0"
 }
 
 description = {
@@ -14,6 +14,7 @@ description = {
 }
 
 dependencies = {
+  "lua-resty-openssl",
 }
 
 build = {

--- a/kong/plugins/aws-lambda/handler.lua
+++ b/kong/plugins/aws-lambda/handler.lua
@@ -306,6 +306,6 @@ function AWSLambdaHandler:access(conf)
 end
 
 AWSLambdaHandler.PRIORITY = 750
-AWSLambdaHandler.VERSION = "3.0.1"
+AWSLambdaHandler.VERSION = "3.4.0"
 
 return AWSLambdaHandler

--- a/kong/plugins/aws-lambda/v4.lua
+++ b/kong/plugins/aws-lambda/v4.lua
@@ -3,7 +3,7 @@
 
 local resty_sha256 = require "resty.sha256"
 local pl_string = require "pl.stringx"
-local openssl_hmac = require "openssl.hmac"
+local openssl_hmac = require "resty.openssl.hmac"
 
 local ALGORITHM = "AWS4-HMAC-SHA256"
 


### PR DESCRIPTION
### Summary

- Changes `local openssl_hmac = require "openssl.hmac"` to
`local openssl_hmac = require "resty.openssl.hmac"`
- Remove hardcoded list of AWS regions
- Make Lambda host configurable