### PR TITLE
feat(schema) add host config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## Unreleased
 
-- Fix: do not validate region name against hardcoded list of regions
+- fix: do not validate region name against hardcoded list of regions
+- feat: add `host` configuration to allow for custom Lambda endpoints
 
 ## aws-lambda 3.3.0 17-Apr-2020
 

--- a/README.md
+++ b/README.md
@@ -115,13 +115,14 @@ Here's a list of all the parameters which can be used in this plugin's configura
 | `consumer_id` || The id of the Consumer which this plugin will target.
 |`config.aws_key` <br>*semi-optional* || The AWS key credential to be used when invoking the function. This value is required if `aws_secret` is defined.
 |`config.aws_secret` <br>*semi-optional* ||The AWS secret credential to be used when invoking the function. This value is required if `aws_key` is defined.
-|`config.aws_region` || The AWS region where the Lambda function is located. The plugin *does not* attempt to validate the provided region name; an invalid region name will result in a DNS name resolution error.
+|`config.aws_region` <br>*semi-optional* || The AWS region where the Lambda function is located. The plugin *does not* attempt to validate the provided region name; an invalid region name will result in a DNS name resolution error. This value cannot be specified if `host` is set.
 |`config.function_name` || The AWS Lambda function name to invoke.
 |`config.timeout`| `60000` | Timeout protection in milliseconds when invoking the function.
 |`config.keepalive`| `60000` | Max idle timeout in milliseconds when invoking the function.
 |`config.qualifier` <br>*optional* || The [`Qualifier`](http://docs.aws.amazon.com/lambda/latest/dg/API_Invoke.html#API_Invoke_RequestSyntax) to use when invoking the function.
 |`config.invocation_type` <br>*optional*| `RequestResponse` | The [`InvocationType`](http://docs.aws.amazon.com/lambda/latest/dg/API_Invoke.html#API_Invoke_RequestSyntax) to use when invoking the function. Available types are `RequestResponse`, `Event`, `DryRun`.
 |`config.log_type` <br>*optional* | `Tail`| The [`LogType`](http://docs.aws.amazon.com/lambda/latest/dg/API_Invoke.html#API_Invoke_RequestSyntax) to use when invoking the function. By default `None` and `Tail` are supported.
+|`config.host` <br>*semi-optional* || The AWS lambda host. If not specified, `aws_region` is required and the official AWS lambda endpoint for the given AWS region is used as host.
 |`config.port` <br>*optional* | `443` | The TCP port that this plugin will use to connect to the server.
 |`config.unhandled_status` <br>*optional* | `200`, `202` or `204` | The response status code to use (instead of the default `200`, `202`, or `204`) in the case of an [`Unhandled` Function Error](https://docs.aws.amazon.com/lambda/latest/dg/API_Invoke.html#API_Invoke_ResponseSyntax)
 |`config.forward_request_body` <br>*optional* | `false` | An optional value that defines whether the request body is to be sent in the `request_body` field of the JSON-encoded request. If the body arguments can be parsed, they will be sent in the separate `request_body_args` field of the request. The body arguments can be parsed for `application/json`, `application/x-www-form-urlencoded`, and `multipart/form-data` content types.

--- a/kong/plugins/aws-lambda/handler.lua
+++ b/kong/plugins/aws-lambda/handler.lua
@@ -163,7 +163,7 @@ function AWSLambdaHandler:access(conf)
     " to forward request values: ", err)
   end
 
-  local host = fmt("lambda.%s.amazonaws.com", conf.aws_region)
+  local host = conf.host or fmt("lambda.%s.amazonaws.com", conf.aws_region)
   local path = fmt("/2015-03-31/functions/%s/invocations",
                             conf.function_name)
   local port = conf.port or AWS_PORT

--- a/kong/plugins/aws-lambda/schema.lua
+++ b/kong/plugins/aws-lambda/schema.lua
@@ -37,7 +37,7 @@ return {
           type = "string",
           encrypted = ENCRYPTED,
         } },
-        { aws_region = typedefs.host { required = true } },
+        { aws_region = typedefs.host },
         { function_name = {
           type = "string",
           required = true,
@@ -57,6 +57,7 @@ return {
           default = "Tail",
           one_of = { "Tail", "None" }
         } },
+        { host = typedefs.host },
         { port = typedefs.port { default = 443 }, },
         { unhandled_status = {
           type = "integer",
@@ -101,5 +102,6 @@ return {
   entity_checks = {
     { mutually_required = { "config.aws_key", "config.aws_secret" } },
     { mutually_required = { "config.proxy_scheme", "config.proxy_url" } },
+    { only_one_of = { "config.aws_region", "config.host" } },
   }
 }

--- a/spec/plugins/aws-lambda/02-schema_spec.lua
+++ b/spec/plugins/aws-lambda/02-schema_spec.lua
@@ -90,4 +90,35 @@ describe("Plugin: AWS Lambda (schema)", function()
     assert.falsy(ok)
   end)
 
+  it("accepts a host", function()
+    local ok, err = v({
+      host = "my.lambda.host",
+      function_name = "my-function"
+    }, schema_def)
+
+    assert.is_nil(err)
+    assert.truthy(ok)
+  end)
+
+  it("errors if none of aws_region and host are passed ", function()
+    local ok, err = v({
+      function_name = "my-function"
+    }, schema_def)
+
+
+    assert.equal("only one of these fields must be non-empty: 'config.aws_region', 'config.host'", err["@entity"][1])
+    assert.falsy(ok)
+  end)
+
+  it("errors if both of aws_region and host are passed ", function()
+    local ok, err = v({
+      host = "my.lambda.host",
+      aws_region = "us-east-1",
+      function_name = "my-function"
+    }, schema_def)
+
+
+    assert.equal("only one of these fields must be non-empty: 'config.aws_region', 'config.host'", err["@entity"][1])
+    assert.falsy(ok)
+  end)
 end)


### PR DESCRIPTION
Introduce a `config.host` field, allowing the AWS endpoint to be
overriden - useful, e.g., for local testing.

closes #26 