### PR TITLE
feat(body) adding support for 'isBase64Encoded' flag in Lambda function responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Kong AWS Lambda plugin changelog
 
+## unreleased
+
+- feat(body) adding support for 'isBase64Encoded' flag in Lambda function
+  responses
+
 ## aws-lambda 3.4.0 12-May-2020
 
 - Change `luaossl` to `lua-resty-openssl`

--- a/kong/plugins/aws-lambda/handler.lua
+++ b/kong/plugins/aws-lambda/handler.lua
@@ -96,13 +96,16 @@ local function extract_proxy_response(content)
   local headers = serialized_content.headers or {}
   local body = serialized_content.body or ""
   local isBase64Encoded = serialized_content.isBase64Encoded or false
+  if isBase64Encoded then
+    body = ngx_decode_base64(body)
+  end
+
   headers["Content-Length"] = #body
 
   return {
     status_code = tonumber(serialized_content.statusCode),
     body = body,
     headers = headers,
-    isBase64Encoded = isBase64Encoded
   }
 end
 
@@ -285,11 +288,7 @@ function AWSLambdaHandler:access(conf)
 
     status = proxy_response.status_code
     headers = kong.table.merge(headers, proxy_response.headers)
-    if proxy_response.isBase64Encoded then
-      content = ngx_decode_base64(proxy_response.body)
-    else
-      content = proxy_response.body
-    end
+    content = proxy_response.body
   end
 
   if not status then

--- a/spec/plugins/aws-lambda/99-access_spec.lua
+++ b/spec/plugins/aws-lambda/99-access_spec.lua
@@ -8,7 +8,6 @@ local TEST_CONF = helpers.test_conf
 local server_tokens = meta._SERVER_TOKENS
 local null = ngx.null
 
-
 local fixtures = {
   dns_mock = helpers.dns_mock.new(),
   http_mock = {
@@ -41,6 +40,9 @@ local fixtures = {
 
                     elseif string.match(ngx.var.uri, "functionWithNoResponse") then
                       ngx.header["Content-Length"] = 0
+
+                    elseif string.match(ngx.var.uri, "functionWithBase64EncodedResponse") then
+                      ngx.say("{\"statusCode\": 200, \"body\": \"dGVzdA==\", \"isBase64Encoded\": true}")
 
                     elseif type(res) == 'string' then
                       ngx.header["Content-Length"] = #res + 1
@@ -180,6 +182,12 @@ for _, strategy in helpers.each_strategy() do
 
       local route15 = bp.routes:insert {
         hosts       = { "lambda15.com" },
+        protocols   = { "http", "https" },
+        service     = null,
+      }
+
+      local route16 = bp.routes:insert {
+        hosts       = { "lambda16.com" },
         protocols   = { "http", "https" },
         service     = null,
       }
@@ -391,6 +399,19 @@ for _, strategy in helpers.each_strategy() do
           aws_region    = "ab-cdef-1",
           function_name = "kongLambdaTest",
         },
+      }
+
+      bp.plugins:insert {
+        name     = "aws-lambda",
+        route    = { id = route16.id },
+        config                 = {
+          port                 = 10001,
+          aws_key              = "mock-key",
+          aws_secret           = "mock-secret",
+          aws_region           = "us-east-1",
+          function_name        = "functionWithBase64EncodedResponse",
+          is_proxy_integration = true,
+        }
       }
 
       assert(helpers.start_kong({
@@ -945,6 +966,18 @@ for _, strategy in helpers.each_strategy() do
         assert.is_string(res.headers["x-amzn-RequestId"])
         assert.equal("some_value1", body.key1)
         assert.is_nil(res.headers["X-Amz-Function-Error"])
+      end)
+
+      it("returns decoded base64 response from a Lambda function", function()
+        local res = assert(proxy_client:send {
+          method  = "GET",
+          path    = "/get?key1=some_value1&key2=some_value2&key3=some_value3",
+          headers = {
+            ["Host"] = "lambda16.com"
+          }
+        })
+        assert.res_status(200, res)
+        assert.equal("test", res:read_body())
       end)
     end)
   end)

--- a/spec/plugins/aws-lambda/99-access_spec.lua
+++ b/spec/plugins/aws-lambda/99-access_spec.lua
@@ -8,6 +8,7 @@ local TEST_CONF = helpers.test_conf
 local server_tokens = meta._SERVER_TOKENS
 local null = ngx.null
 
+
 local fixtures = {
   dns_mock = helpers.dns_mock.new(),
   http_mock = {


### PR DESCRIPTION
Currently the AWS Lambda plugin does not support the `isBase64Encoded` flag that allows Lambda functions to respond with binary payloads. This PR adds that functionality.