### PR TITLE
fix: honor skip_large_bodies config setting when not using AWS API Gateway compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 # Kong AWS Lambda plugin changelog
 
-## unreleased
+## aws-lambda UNRELEASED
 
-- feat(body) adding support for 'isBase64Encoded' flag in Lambda function
-  responses
+- feat: adding support for 'isBase64Encoded' flag in Lambda function responses
+- fix: respect `skip_large_bodies` config setting even when not using
+  AWS API Gateway compatibility
 
 ## aws-lambda 3.4.0 12-May-2020
 

--- a/kong-plugin-aws-lambda-3.4.0-1.rockspec
+++ b/kong-plugin-aws-lambda-3.4.0-1.rockspec
@@ -1,10 +1,10 @@
 package = "kong-plugin-aws-lambda"
-version = "3.4.1-0"
+version = "3.4.0-1"
 
 supported_platforms = {"linux", "macosx"}
 source = {
-  url = "https://github.com/Kong/kong-plugin-aws-lambda/archive/3.4.1.tar.gz",
-  dir = "kong-plugin-aws-lambda-3.4.1"
+  url = "https://github.com/Kong/kong-plugin-aws-lambda/archive/3.4.0.tar.gz",
+  dir = "kong-plugin-aws-lambda-3.4.0"
 }
 
 description = {

--- a/kong-plugin-aws-lambda-3.4.1-0.rockspec
+++ b/kong-plugin-aws-lambda-3.4.1-0.rockspec
@@ -1,10 +1,10 @@
 package = "kong-plugin-aws-lambda"
-version = "3.4.0-1"
+version = "3.4.1-0"
 
 supported_platforms = {"linux", "macosx"}
 source = {
-  url = "https://github.com/Kong/kong-plugin-aws-lambda/archive/3.4.0.tar.gz",
-  dir = "kong-plugin-aws-lambda-3.4.0"
+  url = "https://github.com/Kong/kong-plugin-aws-lambda/archive/3.4.1.tar.gz",
+  dir = "kong-plugin-aws-lambda-3.4.1"
 }
 
 description = {
@@ -27,5 +27,6 @@ build = {
     ["kong.plugins.aws-lambda.schema"]               = "kong/plugins/aws-lambda/schema.lua",
     ["kong.plugins.aws-lambda.v4"]                   = "kong/plugins/aws-lambda/v4.lua",
     ["kong.plugins.aws-lambda.http.connect-better"]  = "kong/plugins/aws-lambda/http/connect-better.lua",
+    ["kong.plugins.aws-lambda.request-util"]         = "kong/plugins/aws-lambda/request-util.lua",
   }
 }

--- a/kong/plugins/aws-lambda/aws-serializer.lua
+++ b/kong/plugins/aws-lambda/aws-serializer.lua
@@ -2,7 +2,7 @@
 -- format as described here:
 -- https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-lambda-proxy-integrations.html#api-gateway-simple-proxy-for-lambda-input-format
 
-local req_read_body = require "kong.plugins.aws-lambda.request-util"
+local request_util = require "kong.plugins.aws-lambda.request-util"
 
 local EMPTY = {}
 
@@ -54,8 +54,9 @@ return function(ctx, config)
 
   -- prepare body
   local body, isBase64Encoded
+  local skip_large_bodies = config and config.skip_large_bodies or true
   do
-    body = req_read_body(config)
+    body = request_util.read_request_body(skip_large_bodies)
     if body ~= "" then
       body = ngx_encode_base64(body)
       isBase64Encoded = true

--- a/kong/plugins/aws-lambda/aws-serializer.lua
+++ b/kong/plugins/aws-lambda/aws-serializer.lua
@@ -2,18 +2,13 @@
 -- format as described here:
 -- https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-lambda-proxy-integrations.html#api-gateway-simple-proxy-for-lambda-input-format
 
+local req_read_body = require "kong.plugins.aws-lambda.request-util"
 
 local EMPTY = {}
 
 local ngx_req_get_headers  = ngx.req.get_headers
 local ngx_req_get_uri_args = ngx.req.get_uri_args
 local ngx_encode_base64    = ngx.encode_base64
-local ngx_req_read_body    = ngx.req.read_body
-local ngx_req_get_body_data= ngx.req.get_body_data
-local ngx_req_get_body_file= ngx.req.get_body_file
-local ngx_log              = ngx.log
-local ERR                  = ngx.ERR
-
 
 return function(ctx, config)
   ctx = ctx or ngx.ctx
@@ -60,21 +55,7 @@ return function(ctx, config)
   -- prepare body
   local body, isBase64Encoded
   do
-    ngx_req_read_body()
-    body = ngx_req_get_body_data()
-    if not body then
-      local body_filepath = ngx_req_get_body_file()
-      if body_filepath then
-        if config.skip_large_bodies then
-          ngx_log(ERR, "request body was buffered to disk, too large")
-        else
-          local file = io.open(body_filepath, "rb")
-          body = file:read("*all")
-          file:close()
-        end
-      end
-    end
-
+    body = req_read_body(config)
     if body ~= "" then
       body = ngx_encode_base64(body)
       isBase64Encoded = true

--- a/kong/plugins/aws-lambda/handler.lua
+++ b/kong/plugins/aws-lambda/handler.lua
@@ -6,7 +6,8 @@ local http = require "kong.plugins.aws-lambda.http.connect-better"
 local cjson = require "cjson.safe"
 local meta = require "kong.meta"
 local constants = require "kong.constants"
-local req_read_body = require "kong.plugins.aws-lambda.request-util"
+local request_util = require "kong.plugins.aws-lambda.request-util"
+
 
 local VIA_HEADER = constants.HEADERS.VIA
 local VIA_HEADER_VALUE = meta._NAME .. "/" .. meta._VERSION
@@ -141,7 +142,8 @@ function AWSLambdaHandler:access(conf)
 
     if conf.forward_request_body then
       local content_type = kong.request.get_header("content-type")
-      local body_raw = req_read_body(conf)
+      local skip_large_bodies = config and config.skip_large_bodies or true
+      local body_raw = request_util.read_request_body(skip_large_bodies)
       local body_args, err = kong.request.get_body()
       if err and err:match("content type") then
         body_args = {}

--- a/kong/plugins/aws-lambda/handler.lua
+++ b/kong/plugins/aws-lambda/handler.lua
@@ -142,7 +142,7 @@ function AWSLambdaHandler:access(conf)
 
     if conf.forward_request_body then
       local content_type = kong.request.get_header("content-type")
-      local skip_large_bodies = config and config.skip_large_bodies or true
+      local skip_large_bodies = conf and conf.skip_large_bodies or true
       local body_raw = request_util.read_request_body(skip_large_bodies)
       local body_args, err = kong.request.get_body()
       if err and err:match("content type") then

--- a/kong/plugins/aws-lambda/handler.lua
+++ b/kong/plugins/aws-lambda/handler.lua
@@ -6,7 +6,7 @@ local http = require "kong.plugins.aws-lambda.http.connect-better"
 local cjson = require "cjson.safe"
 local meta = require "kong.meta"
 local constants = require "kong.constants"
-
+local req_read_body = require "kong.plugins.aws-lambda.request-util"
 
 local VIA_HEADER = constants.HEADERS.VIA
 local VIA_HEADER_VALUE = meta._NAME .. "/" .. meta._VERSION
@@ -141,7 +141,7 @@ function AWSLambdaHandler:access(conf)
 
     if conf.forward_request_body then
       local content_type = kong.request.get_header("content-type")
-      local body_raw = kong.request.get_raw_body()
+      local body_raw = req_read_body(conf)
       local body_args, err = kong.request.get_body()
       if err and err:match("content type") then
         body_args = {}

--- a/kong/plugins/aws-lambda/request-util.lua
+++ b/kong/plugins/aws-lambda/request-util.lua
@@ -1,0 +1,22 @@
+local ERR = ngx.ERR
+
+return function(config)
+  ngx.req.read_body()
+  local body = ngx.req.get_body_data()
+
+  if not body then
+    -- see if body was buffered to tmp file, payload could have exceeded client_body_buffer_size
+    local body_filepath = ngx.req.get_body_file()
+    if body_filepath then
+      if config.skip_large_bodies then
+        ngx.log(ERR, "request body was buffered to disk, too large")
+      else
+        local file = io.open(body_filepath, "rb")
+        body = file:read("*all")
+        file:close()
+      end
+    end
+  end
+
+  return body
+end

--- a/kong/plugins/aws-lambda/request-util.lua
+++ b/kong/plugins/aws-lambda/request-util.lua
@@ -1,6 +1,6 @@
 local ERR = ngx.ERR
 
-return function(config)
+local function read_request_body(skip_large_bodies)
   ngx.req.read_body()
   local body = ngx.req.get_body_data()
 
@@ -8,7 +8,7 @@ return function(config)
     -- see if body was buffered to tmp file, payload could have exceeded client_body_buffer_size
     local body_filepath = ngx.req.get_body_file()
     if body_filepath then
-      if config.skip_large_bodies then
+      if skip_large_bodies then
         ngx.log(ERR, "request body was buffered to disk, too large")
       else
         local file = io.open(body_filepath, "rb")
@@ -20,3 +20,8 @@ return function(config)
 
   return body
 end
+
+
+return {
+  read_request_body = read_request_body
+}

--- a/spec/plugins/aws-lambda/06-request-util_spec.lua
+++ b/spec/plugins/aws-lambda/06-request-util_spec.lua
@@ -1,0 +1,130 @@
+local default_client_body_buffer_size = 1024 * 8
+
+describe("[AWS Lambda] request-util", function()
+
+  local mock_request
+  local old_ngx
+  local req_read_body
+  local body_data
+  local body_data_filepath
+
+
+  function mock_read_body()
+    body_data = mock_request.body
+
+    -- if the request body is greater than the client buffer size, buffer
+    -- it to disk and set the filepath
+    if #body_data > default_client_body_buffer_size then
+      body_data_filepath = os.tmpname()
+      local f = io.open(body_data_filepath, "w")
+      f:write(body_data)
+      f:close()
+      body_data = nil
+    end
+  end
+
+  -- will be nil if request wasn't large enough to buffer
+  function mock_get_body_file()
+    return body_data_filepath
+  end
+
+  -- will be nil if request was large and required buffering
+  function mock_get_body_data()
+    return body_data
+  end
+
+  setup(function()
+    old_ngx = ngx
+    _G.ngx = setmetatable({
+      req = {
+        read_body = mock_read_body,
+        get_body_data = mock_get_body_data,
+        get_body_file = mock_get_body_file
+      },
+      log = function() end,
+    }, {
+      -- look up any unknown key in the mock request, eg. .var and .ctx tables
+      __index = function(self, key)
+        return mock_request and mock_request[key]
+      end,
+    })
+
+    -- always reload
+    package.loaded["kong.plugins.aws-lambda.request-util"] = nil
+    req_read_body = require "kong.plugins.aws-lambda.request-util"
+  end)
+
+
+  teardown(function()
+
+    body_data = nil
+
+    -- ignore return value, file might not exist
+    os.remove(body_data_filepath)
+
+    body_data_filepath = nil
+
+    -- always unload and restore
+    package.loaded["kong.plugins.aws-lambda.request-util"] = nil
+    ngx = old_ngx         -- luacheck: ignore
+  end)
+
+
+  describe("when skip_large_bodies is true", function()
+    local config = {skip_large_bodies = true}
+
+    it("it skips file-buffered body > max buffer size", function()
+      mock_request = {
+        body = string.rep("x", 1024 * 9 )
+      }
+      spy.on(ngx.req, "read_body")
+      spy.on(ngx.req, "get_body_file")
+      local out = req_read_body(config)
+      assert.spy(ngx.req.read_body).was.called(1)
+      -- the payload was buffered to disk, but won't be read because we're skipping
+      assert.spy(ngx.req.get_body_file).was.called(1)
+      assert.is_nil(out)
+    end)
+
+    it("it reads body < max buffer size", function()
+      mock_request = {
+        body = string.rep("x", 1024 * 2 )
+      }
+      spy.on(ngx.req, "read_body")
+      spy.on(ngx.req, "get_body_file")
+      local out = req_read_body(config)
+      assert.spy(ngx.req.read_body).was.called(1)
+      assert.spy(ngx.req.get_body_file).was.called(0)
+      assert.is_not_nil(out)
+    end)
+  end)
+
+  describe("when skip_large_bodies is false", function()
+    local config = {skip_large_bodies = false}
+
+    it("it reads file-buffered body > max buffer size", function()
+      mock_request = {
+        body = string.rep("x", 1024 * 10 )
+      }
+      spy.on(ngx.req, "read_body")
+      spy.on(ngx.req, "get_body_file")
+      local out = req_read_body(config)
+      assert.spy(ngx.req.read_body).was.called(1)
+      -- this payload was buffered to disk, and was read
+      assert.spy(ngx.req.get_body_file).was.called(1)
+      assert.is_not_nil(out)
+    end)
+
+    it("it reads body < max buffer size", function()
+      mock_request = {
+        body = string.rep("x", 1024 * 2 )
+      }
+      spy.on(ngx.req, "read_body")
+      spy.on(ngx.req, "get_body_file")
+      local out = req_read_body(config)
+      assert.spy(ngx.req.read_body).was.called(1)
+      assert.spy(ngx.req.get_body_file).was.called(0)
+      assert.is_not_nil(out)
+    end)
+  end)
+end)

--- a/spec/plugins/aws-lambda/06-request-util_spec.lua
+++ b/spec/plugins/aws-lambda/06-request-util_spec.lua
@@ -1,10 +1,11 @@
+local request_util = require "kong.plugins.aws-lambda.request-util"
 local default_client_body_buffer_size = 1024 * 8
 
 describe("[AWS Lambda] request-util", function()
 
   local mock_request
   local old_ngx
-  local req_read_body
+  local request_util
   local body_data
   local body_data_filepath
 
@@ -45,7 +46,7 @@ describe("[AWS Lambda] request-util", function()
 
     -- always reload
     package.loaded["kong.plugins.aws-lambda.request-util"] = nil
-    req_read_body = require "kong.plugins.aws-lambda.request-util"
+    request_util = require "kong.plugins.aws-lambda.request-util"
   end)
 
 
@@ -73,7 +74,7 @@ describe("[AWS Lambda] request-util", function()
       }
       spy.on(ngx.req, "read_body")
       spy.on(ngx.req, "get_body_file")
-      local out = req_read_body(config)
+      local out = request_util.read_request_body(config.skip_large_bodies)
       assert.spy(ngx.req.read_body).was.called(1)
       -- the payload was buffered to disk, but won't be read because we're skipping
       assert.spy(ngx.req.get_body_file).was.called(1)
@@ -86,7 +87,7 @@ describe("[AWS Lambda] request-util", function()
       }
       spy.on(ngx.req, "read_body")
       spy.on(ngx.req, "get_body_file")
-      local out = req_read_body(config)
+      local out = request_util.read_request_body(config.skip_large_bodies)
       assert.spy(ngx.req.read_body).was.called(1)
       assert.spy(ngx.req.get_body_file).was.called(0)
       assert.is_not_nil(out)
@@ -102,7 +103,7 @@ describe("[AWS Lambda] request-util", function()
       }
       spy.on(ngx.req, "read_body")
       spy.on(ngx.req, "get_body_file")
-      local out = req_read_body(config)
+      local out = request_util.read_request_body(config.skip_large_bodies)
       assert.spy(ngx.req.read_body).was.called(1)
       -- this payload was buffered to disk, and was read
       assert.spy(ngx.req.get_body_file).was.called(1)
@@ -115,7 +116,7 @@ describe("[AWS Lambda] request-util", function()
       }
       spy.on(ngx.req, "read_body")
       spy.on(ngx.req, "get_body_file")
-      local out = req_read_body(config)
+      local out = request_util.read_request_body(config.skip_large_bodies)
       assert.spy(ngx.req.read_body).was.called(1)
       assert.spy(ngx.req.get_body_file).was.called(0)
       assert.is_not_nil(out)

--- a/spec/plugins/aws-lambda/06-request-util_spec.lua
+++ b/spec/plugins/aws-lambda/06-request-util_spec.lua
@@ -1,4 +1,3 @@
-local request_util = require "kong.plugins.aws-lambda.request-util"
 local default_client_body_buffer_size = 1024 * 8
 
 describe("[AWS Lambda] request-util", function()


### PR DESCRIPTION
Currently, payloads that exceed the nginx `client_body_buffer_size` are dropped without warning, causing lambda invocations to receive empty request bodies. The `get_raw_body` function used by the plugin's handler will return nil for any payload that is greater than the configured client buffer size. The `skip_large_bodies` config setting was introduced in #4, but is only used by the AWS serializer, and is ignored when `awsgateway_compatible` is false (the default).

This PR extracts the request body read logic into a common function, and uses that if `forward_request_body` is true (as well as the current APIGW compat scenario). I added ERR logging when `skip_large_bodies` is true and the body exceeds the buffer size; that could be refactored into a config setting if it's too noisy, but it's far better than just dropping requests on the floor silently.

This issue is blocking my production migration away from AWS APIGW to Kong, so if there's anything missing from this PR, I'll be glad to modify.