### PR TITLE
chore(*) tests and release 3.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,11 @@
 - test rockspec; `luarocks install kong-plugin-aws-lambda`
 
 
-## aws-lambda 3.5.1 6-Okt-2020
+## aws-lambda 3.5.2 6-Nov-2020
+
+- tests: just fix test suite for upcoming change to `ssl_cert` on Kong project
+
+## aws-lambda 3.5.1 6-Oct-2020
 
 - fix: `skip_large_bodies` to honor config setting
 

--- a/kong-plugin-aws-lambda-3.5.2-1.rockspec
+++ b/kong-plugin-aws-lambda-3.5.2-1.rockspec
@@ -1,10 +1,10 @@
 package = "kong-plugin-aws-lambda"
-version = "3.5.1-1"
+version = "3.5.2-1"
 
 supported_platforms = {"linux", "macosx"}
 source = {
   url = "git://github.com/kong/kong-plugin-aws-lambda",
-  tag = "3.5.1",
+  tag = "3.5.2",
 }
 
 description = {

--- a/kong/plugins/aws-lambda/handler.lua
+++ b/kong/plugins/aws-lambda/handler.lua
@@ -313,6 +313,6 @@ function AWSLambdaHandler:access(conf)
 end
 
 AWSLambdaHandler.PRIORITY = 750
-AWSLambdaHandler.VERSION = "3.5.1"
+AWSLambdaHandler.VERSION = "3.5.2"
 
 return AWSLambdaHandler

--- a/spec/plugins/aws-lambda/99-access_spec.lua
+++ b/spec/plugins/aws-lambda/99-access_spec.lua
@@ -17,9 +17,15 @@ local fixtures = {
       server {
           server_name mock_aws_lambda;
           listen 10001 ssl;
-
+> if ssl_cert[1] then
+> for i = 1, #ssl_cert do
+          ssl_certificate     $(ssl_cert[i]);
+          ssl_certificate_key $(ssl_cert_key[i]);
+> end
+> else
           ssl_certificate ${{SSL_CERT}};
           ssl_certificate_key ${{SSL_CERT_KEY}};
+> end
           ssl_protocols TLSv1.1 TLSv1.2 TLSv1.3;
 
           location ~ "/2015-03-31/functions/(?:[^/])*/invocations" {


### PR DESCRIPTION
### Summary

On Kong there is a PR:
Kong/kong#6509

That changes Kong template variable `ssl_cert` and friends to array instead of a `string` that it used to be. The mentioned PR is red because this plugin uses them as `strings`. This commit makes it work with both.

This also bumps the version in second commit, so that we can then release this and Kong will pick it up, and hopefully we get the tests green then.