### PR TITLE
Fix #44 and #45; honor skip_large_bodies while also giving it a default of true

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ servroot
 
 # packed distribution format for LuaRocks
 *.rock
+# exclude Pongo shell history
+.pongo/.ash_history

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,16 +2,16 @@ dist: bionic
 
 jobs:
   include:
-  - name: Enterprise 1.3.0.x
-    env: KONG_VERSION=1.3.0.x
-  - name: Enterprise 1.5.0.x
-    env: KONG_VERSION=1.5.0.x
-  - name: Kong CE 1.3.x
-    env: KONG_VERSION=1.3.x
-  - name: Kong CE 1.5.x
-    env: KONG_VERSION=1.5.x
-  - name: Kong CE 2.0.x
-    env: KONG_VERSION=2.0.x
+  - name: Enterprise 2.1.4.x
+    env: KONG_VERSION=2.1.4.x
+  - name: Enterprise 2.2.1.x
+    env: KONG_VERSION=2.2.1.x
+  - name: Kong CE 2.1.x
+    env: KONG_VERSION=2.1.x
+  - name: Kong CE 2.2.x
+    env: KONG_VERSION=2.2.x
+  - name: Kong CE 2.3.x
+    env: KONG_VERSION=2.3.x
   - name: Nightly EE-master
     env: KONG_VERSION=nightly-ee POSTGRES=latest CASSANDRA=latest
   #- name: Nightly CE-master

--- a/kong/plugins/aws-lambda/aws-serializer.lua
+++ b/kong/plugins/aws-lambda/aws-serializer.lua
@@ -54,7 +54,10 @@ return function(ctx, config)
 
   -- prepare body
   local body, isBase64Encoded
-  local skip_large_bodies = config and config.skip_large_bodies or true
+  local skip_large_bodies = true
+  if config and config.skip_large_bodies ~= nil then
+    skip_large_bodies = config.skip_large_bodies
+  end
   do
     body = request_util.read_request_body(skip_large_bodies)
     if body ~= "" then

--- a/spec/plugins/aws-lambda/99-access_spec.lua
+++ b/spec/plugins/aws-lambda/99-access_spec.lua
@@ -2,100 +2,12 @@ local cjson   = require "cjson"
 local helpers = require "spec.helpers"
 local meta    = require "kong.meta"
 local pl_file = require "pl.file"
-
+local fixtures = require "spec.plugins.aws-lambda.fixtures"
 
 local TEST_CONF = helpers.test_conf
 local server_tokens = meta._SERVER_TOKENS
 local null = ngx.null
 
-
-local fixtures = {
-  dns_mock = helpers.dns_mock.new(),
-  http_mock = {
-    lambda_plugin = [[
-
-      server {
-          server_name mock_aws_lambda;
-          listen 10001 ssl;
-> if ssl_cert[1] then
-> for i = 1, #ssl_cert do
-          ssl_certificate     $(ssl_cert[i]);
-          ssl_certificate_key $(ssl_cert_key[i]);
-> end
-> else
-          ssl_certificate ${{SSL_CERT}};
-          ssl_certificate_key ${{SSL_CERT_KEY}};
-> end
-          ssl_protocols TLSv1.1 TLSv1.2 TLSv1.3;
-
-          location ~ "/2015-03-31/functions/(?:[^/])*/invocations" {
-              content_by_lua_block {
-                local function x()
-                  local function say(res, status)
-                    ngx.header["x-amzn-RequestId"] = "foo"
-
-                    if string.match(ngx.var.uri, "functionWithUnhandledError") then
-                      ngx.header["X-Amz-Function-Error"] = "Unhandled"
-                    end
-
-                    ngx.status = status
-
-                    if string.match(ngx.var.uri, "functionWithBadJSON") then
-                      local badRes = "{\"foo\":\"bar\""
-                      ngx.header["Content-Length"] = #badRes + 1
-                      ngx.say(badRes)
-
-                    elseif string.match(ngx.var.uri, "functionWithNoResponse") then
-                      ngx.header["Content-Length"] = 0
-
-                    elseif string.match(ngx.var.uri, "functionWithBase64EncodedResponse") then
-                      ngx.say("{\"statusCode\": 200, \"body\": \"dGVzdA==\", \"isBase64Encoded\": true}")
-
-                    elseif type(res) == 'string' then
-                      ngx.header["Content-Length"] = #res + 1
-                      ngx.say(res)
-
-                    else
-                      ngx.req.discard_body()
-                      ngx.header['Content-Length'] = 0
-                    end
-
-                    ngx.exit(0)
-                  end
-
-                  ngx.sleep(.2) -- mock some network latency
-
-                  local invocation_type = ngx.var.http_x_amz_invocation_type
-                  if invocation_type == 'Event' then
-                    say(nil, 202)
-
-                  elseif invocation_type == 'DryRun' then
-                    say(nil, 204)
-                  end
-
-                  local qargs = ngx.req.get_uri_args()
-                  ngx.req.read_body()
-                  local args = require("cjson").decode(ngx.req.get_body_data())
-
-                  say(ngx.req.get_body_data(), 200)
-                end
-                local ok, err = pcall(x)
-                if not ok then
-                  ngx.log(ngx.ERR, "Mock error: ", err)
-                end
-              }
-          }
-      }
-
-    ]]
-  },
-}
-
-
-fixtures.dns_mock:A {
-  name = "lambda.us-east-1.amazonaws.com",
-  address = "127.0.0.1",
-}
 
 
 for _, strategy in helpers.each_strategy() do

--- a/spec/plugins/aws-lambda/fixtures.lua
+++ b/spec/plugins/aws-lambda/fixtures.lua
@@ -1,0 +1,102 @@
+local helpers = require "spec.helpers"
+
+local fixtures = {
+  dns_mock = helpers.dns_mock.new(),
+  http_mock = {
+    lambda_plugin = [[
+
+      server {
+          server_name mock_aws_lambda;
+          listen 10001 ssl;
+> if ssl_cert[1] then
+> for i = 1, #ssl_cert do
+          ssl_certificate     $(ssl_cert[i]);
+          ssl_certificate_key $(ssl_cert_key[i]);
+> end
+> else
+          ssl_certificate ${{SSL_CERT}};
+          ssl_certificate_key ${{SSL_CERT_KEY}};
+> end
+          ssl_protocols TLSv1.1 TLSv1.2 TLSv1.3;
+
+          location ~ "/2015-03-31/functions/(?:[^/])*/invocations" {
+              content_by_lua_block {
+                local function x()
+                  local function say(res, status)
+                    ngx.header["x-amzn-RequestId"] = "foo"
+
+                    if string.match(ngx.var.uri, "functionWithUnhandledError") then
+                      ngx.header["X-Amz-Function-Error"] = "Unhandled"
+                    end
+
+                    ngx.status = status
+
+                    if string.match(ngx.var.uri, "functionWithBadJSON") then
+                      local badRes = "{\"foo\":\"bar\""
+                      ngx.header["Content-Length"] = #badRes + 1
+                      ngx.say(badRes)
+
+                    elseif string.match(ngx.var.uri, "functionWithNoResponse") then
+                      ngx.header["Content-Length"] = 0
+
+                    elseif string.match(ngx.var.uri, "functionWithBase64EncodedResponse") then
+                      ngx.say("{\"statusCode\": 200, \"body\": \"dGVzdA==\", \"isBase64Encoded\": true}")
+
+                    elseif type(res) == 'string' then
+                      ngx.header["Content-Length"] = #res + 1
+                      ngx.say(res)
+
+                    else
+                      ngx.req.discard_body()
+                      ngx.header['Content-Length'] = 0
+                    end
+
+                    ngx.exit(0)
+                  end
+
+                  ngx.sleep(.2) -- mock some network latency
+
+                  local invocation_type = ngx.var.http_x_amz_invocation_type
+                  if invocation_type == 'Event' then
+                    say(nil, 202)
+
+                  elseif invocation_type == 'DryRun' then
+                    say(nil, 204)
+                  end
+
+                  local qargs = ngx.req.get_uri_args()
+                  ngx.req.read_body()
+                  local request_body = ngx.req.get_body_data()
+                  if request_body == nil then
+                    local body_file = ngx.req.get_body_file()
+                    if body_file then
+                      ngx.log(ngx.DEBUG, "reading file cached to disk: ",body_file)
+                      local file = io.open(body_file, "rb")
+                      request_body = file:read("*all")
+                      file:close()
+                    end
+                  end
+                  print(request_body)
+                  local args = require("cjson").decode(request_body)
+
+                  say(request_body, 200)
+                end
+                local ok, err = pcall(x)
+                if not ok then
+                  ngx.log(ngx.ERR, "Mock error: ", err)
+                end
+              }
+          }
+      }
+
+    ]]
+  },
+}
+
+
+fixtures.dns_mock:A {
+  name = "lambda.us-east-1.amazonaws.com",
+  address = "127.0.0.1",
+}
+
+return fixtures


### PR DESCRIPTION
This PR fixes skip_large_bodies so that it is honored. Previously it wasn't honored. Because of the way the code was written, if the setting was defined but false, it would be set to true anyway. This new code allows the default to be true but also checks explicitly to see if the setting was defined first, and if it is, sets it according to what was configured.

Typically, in lua, it is idiomatic to write the line

`a = b or some-default`

This works fine if the type of `a` and `b` are *non-boolean* values, since any value that evaluates to `nil` in lua is considered `false` as evaluated in the above expression. This idiom was used here; however, the value is boolean, and so it also evaluates to false if it is defined (non-nil) and is set to false on purpose.

The new code in the pull request explicitly checks for definition of the value separately so that the original meaning of the line is preserved while also honoring any explicitly configured `false` value.