### PR TITLE
feat(*) configurable body base64 encoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ Here's a list of all the parameters which can be used in this plugin's configura
 |`config.proxy_url` <br>*semi-optional* || An optional value that defines whether the plugin should connect through the given proxy server URL. This value is required if `proxy_scheme` is defined.
 |`config.proxy_scheme` <br>*semi-optional* || An optional value that defines which HTTP protocol scheme to use in order to connect through the proxy server. The schemes supported are: `http` and `https`. This value is required if `proxy_url` is defined.
 |`config.skip_large_bodies` <br>*optional* | `true` | An optional value that defines whether very large bodies (that are buffered to disk) should be sent by Kong. Note that sending very large bodies will have an impact on the system memory.
+|`config.base64_encode_body` <br>*optional* | `true` | An optional value that defines whether request and response bodies should be base64 encoded or not.
 
 ## Notes
 

--- a/kong/plugins/aws-lambda/aws-serializer.lua
+++ b/kong/plugins/aws-lambda/aws-serializer.lua
@@ -55,12 +55,21 @@ return function(ctx, config)
   -- prepare body
   local body, isBase64Encoded
   local skip_large_bodies = true
-  if config and config.skip_large_bodies ~= nil then
-    skip_large_bodies = config.skip_large_bodies
+  local base64_encode_body = true
+
+  if config then
+    if config.skip_large_bodies ~= nil then
+      skip_large_bodies = config.skip_large_bodies
+    end
+
+    if config.base64_encode_body ~= nil then
+      base64_encode_body = config.base64_encode_body
+    end
   end
+
   do
     body = request_util.read_request_body(skip_large_bodies)
-    if body ~= "" then
+    if body ~= "" and base64_encode_body then
       body = ngx_encode_base64(body)
       isBase64Encoded = true
     else

--- a/kong/plugins/aws-lambda/handler.lua
+++ b/kong/plugins/aws-lambda/handler.lua
@@ -146,7 +146,7 @@ function AWSLambdaHandler:access(conf)
       local body_args, err = kong.request.get_body()
       if err and err:match("content type") then
         body_args = {}
-        if not raw_content_types[content_type] then
+        if not raw_content_types[content_type] and conf.base64_encode_body then
           -- don't know what this body MIME type is, base64 it just in case
           body_raw = ngx_encode_base64(body_raw)
           upstream_body.request_body_base64 = true

--- a/kong/plugins/aws-lambda/schema.lua
+++ b/kong/plugins/aws-lambda/schema.lua
@@ -96,6 +96,10 @@ return {
           type = "boolean",
           default = true,
         } },
+        { base64_encode_body = {
+          type = "boolean",
+          default = true,
+        } },
       }
     },
   } },


### PR DESCRIPTION
As not every lambda function uses base64 encoded bodies, now it's possible to completely disable this body encoding. This makes it easier for users who are migrating from an environment where lambda functions are not base64 encoded to Kong.

The default behavior still is encoding the requests and the responses.