### PR TITLE
Detect Region using the metadata service

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,14 +115,14 @@ Here's a list of all the parameters which can be used in this plugin's configura
 | `consumer_id` || The id of the Consumer which this plugin will target.
 |`config.aws_key` <br>*semi-optional* || The AWS key credential to be used when invoking the function. This value is required if `aws_secret` is defined.
 |`config.aws_secret` <br>*semi-optional* ||The AWS secret credential to be used when invoking the function. This value is required if `aws_key` is defined.
-|`config.aws_region` <br>*semi-optional* || The AWS region where the Lambda function is located. The plugin *does not* attempt to validate the provided region name; an invalid region name will result in a DNS name resolution error. This value cannot be specified if `host` is set.
+|`config.aws_region` <br>*optional* || The AWS region where the Lambda function is located. The plugin *does not* attempt to validate the provided region name; an invalid region name will result in a DNS name resolution error. This value cannot be specified if `host` is set. If neither `host` and `aws_region` are set, the plugin will retrieve the `aws_region` from the kong host
 |`config.function_name` || The AWS Lambda function name to invoke.
 |`config.timeout`| `60000` | Timeout protection in milliseconds when invoking the function.
 |`config.keepalive`| `60000` | Max idle timeout in milliseconds when invoking the function.
 |`config.qualifier` <br>*optional* || The [`Qualifier`](http://docs.aws.amazon.com/lambda/latest/dg/API_Invoke.html#API_Invoke_RequestSyntax) to use when invoking the function.
 |`config.invocation_type` <br>*optional*| `RequestResponse` | The [`InvocationType`](http://docs.aws.amazon.com/lambda/latest/dg/API_Invoke.html#API_Invoke_RequestSyntax) to use when invoking the function. Available types are `RequestResponse`, `Event`, `DryRun`.
 |`config.log_type` <br>*optional* | `Tail`| The [`LogType`](http://docs.aws.amazon.com/lambda/latest/dg/API_Invoke.html#API_Invoke_RequestSyntax) to use when invoking the function. By default `None` and `Tail` are supported.
-|`config.host` <br>*semi-optional* || The AWS lambda host. If not specified, `aws_region` is required and the official AWS lambda endpoint for the given AWS region is used as host.
+|`config.host` <br>*optional* || The AWS lambda host. If not specified, `aws_region` will be used and the official AWS lambda endpoint for the given AWS region is used as host.
 |`config.port` <br>*optional* | `443` | The TCP port that this plugin will use to connect to the server.
 |`config.unhandled_status` <br>*optional* | `200`, `202` or `204` | The response status code to use (instead of the default `200`, `202`, or `204`) in the case of an [`Unhandled` Function Error](https://docs.aws.amazon.com/lambda/latest/dg/API_Invoke.html#API_Invoke_ResponseSyntax)
 |`config.forward_request_body` <br>*optional* | `false` | An optional value that defines whether the request body is to be sent in the `request_body` field of the JSON-encoded request. If the body arguments can be parsed, they will be sent in the separate `request_body_args` field of the request. The body arguments can be parsed for `application/json`, `application/x-www-form-urlencoded`, and `multipart/form-data` content types.

--- a/kong/plugins/aws-lambda/handler.lua
+++ b/kong/plugins/aws-lambda/handler.lua
@@ -121,8 +121,11 @@ local AWSLambdaHandler = {}
 function AWSLambdaHandler:access(conf)
   local upstream_body = kong.table.new(0, 6)
   local var = ngx.var
-  if not conf.host and not conf.aws_region and not kong_region then
-    kong_region = fetch_region()
+  if not conf.host and not conf.aws_region then
+    if not kong_region then
+      kong_region = fetch_region()
+    end
+    conf.aws_region = kong_region
   end
 
   if conf.awsgateway_compatible then
@@ -177,7 +180,7 @@ function AWSLambdaHandler:access(conf)
     " to forward request values: ", err)
   end
 
-  local host = conf.host or fmt("lambda.%s.amazonaws.com", conf.aws_region or kong_region)
+  local host = conf.host or fmt("lambda.%s.amazonaws.com", conf.aws_region)
   local path = fmt("/2015-03-31/functions/%s/invocations",
                             conf.function_name)
   local port = conf.port or AWS_PORT

--- a/kong/plugins/aws-lambda/iam-ecs-credentials.lua
+++ b/kong/plugins/aws-lambda/iam-ecs-credentials.lua
@@ -114,6 +114,10 @@ local function fetchCredentials()
   return result, nil, result.expiration - ngx_now()
 end
 
+local function fetchRegion()
+  return nil, "Not implemented"
+end
+
 local function fetchCredentialsLogged()
   -- wrapper to log any errors
   local creds, err, ttl = fetchCredentials()
@@ -123,7 +127,17 @@ local function fetchCredentialsLogged()
   kong.log.err(err)
 end
 
+local function fetchRegionLogged()
+  -- wrapper to log any errors
+  local region, err = fetchRegion()
+  if region then
+    return region, err
+  end
+  kong.log.err(err)
+end
+
 return {
   configured = not not ECSFullUri, -- force to boolean
   fetchCredentials = fetchCredentialsLogged,
+  fetchRegion = fetchRegionLogged,
 }

--- a/spec/plugins/aws-lambda/02-schema_spec.lua
+++ b/spec/plugins/aws-lambda/02-schema_spec.lua
@@ -100,14 +100,14 @@ describe("Plugin: AWS Lambda (schema)", function()
     assert.truthy(ok)
   end)
 
-  it("errors if none of aws_region and host are passed ", function()
+  it("accepts no host neither region", function()
     local ok, err = v({
       function_name = "my-function"
     }, schema_def)
 
 
-    assert.equal("only one of these fields must be non-empty: 'config.aws_region', 'config.host'", err["@entity"][1])
-    assert.falsy(ok)
+    assert.is_nil(err)
+    assert.truthy(ok)
   end)
 
   it("errors if both of aws_region and host are passed ", function()
@@ -118,7 +118,7 @@ describe("Plugin: AWS Lambda (schema)", function()
     }, schema_def)
 
 
-    assert.equal("only one of these fields must be non-empty: 'config.aws_region', 'config.host'", err["@entity"][1])
     assert.falsy(ok)
+    assert.equal("At least one of 'config.aws_region', 'config.host' should not be set", err["@entity"][1])
   end)
 end)

--- a/spec/plugins/aws-lambda/03-iam-ec2-credentials_spec.lua
+++ b/spec/plugins/aws-lambda/03-iam-ec2-credentials_spec.lua
@@ -2,7 +2,7 @@ require "spec.helpers"
 
 describe("[AWS Lambda] iam-ec2", function()
 
-  local fetch_ec2, http_responses
+  local fetch_ec2, fetch_region, http_responses
 
   before_each(function()
     package.loaded["kong.plugins.aws-lambda.iam-ec2-credentials"] = nil
@@ -28,6 +28,7 @@ describe("[AWS Lambda] iam-ec2", function()
       }
     end
     fetch_ec2 = require("kong.plugins.aws-lambda.iam-ec2-credentials").fetchCredentials
+    fetch_region = require("kong.plugins.aws-lambda.iam-ec2-credentials").fetchRegion
   end)
 
   after_each(function()
@@ -56,5 +57,33 @@ describe("[AWS Lambda] iam-ec2", function()
     assert.equal("the Big Secret", iam_role_credentials.secret_key)
     assert.equal("the Token of Appreciation", iam_role_credentials.session_token)
     assert.equal(1552424170, iam_role_credentials.expiration)
+  end)
+  it("should fetch region metadata service", function()
+    http_responses = {
+      [[
+{
+  "accountId" : "832462046160",
+  "architecture" : "x86_64",
+  "availabilityZone" : "eu-west-3b",
+  "billingProducts" : null,
+  "devpayProductCodes" : null,
+  "marketplaceProductCodes" : null,
+  "imageId" : "ami-01b209ce2c9441231",
+  "instanceId" : "i-04c6019ed0f4e7ca7",
+  "instanceType" : "m5d.2xlarge",
+  "kernelId" : null,
+  "pendingTime" : "2021-04-29T09:53:04Z",
+  "privateIp" : "10.196.93.32",
+  "ramdiskId" : null,
+  "region" : "eu-west-3",
+  "version" : "2017-09-30"
+}
+]]
+    }
+
+    local region, err = fetch_region()
+
+    assert.is_nil(err)
+    assert.equal("eu-west-3", region)
   end)
 end)


### PR DESCRIPTION
If `host` and `aws_region` are not set use the metadata of the kong host to get the region.

Our usecase is a multiregion set up, the configuration is shared for the different region, so we need dynamic region.