### PR TITLE
fix(handler) ensure multivalueheaders are handled

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ env:
   - DOCKER_USERNAME=kongcloudpull
   - secure: LruPuOUZuawukX4dYFrkeIQfHLkEqrXMhMgcLzNYYo/0V6vv3M7Nu2sGek8jwReNAbfXYuDM3T1U3PND5FYVJzz/FPGUdBVsCVFipjTeEKEjCrVr7gdB9yeJj91QtJum+sOoIrXj+VuRK+4VCeVhpSfB9WjnIT8NxedH7UkS1THsKA0AVIlUNGFtycS9dfCqzZivPyyVu6woUWQjyytg+90Q7KHMqtz8e3GhETNPP4bVyAjMEnc/0w1KOFJBUK0iPJ/Xbhz61z4RrnjvTG9dV75UHexI4aPOvUVZCCautKUl2TDbjO65eLeMT2+EK9T0c8wUikTjfMc/td5HfszTRs+8oOymUj7UN9LIvUShZ8PdlqiOgsIvJKrrzHkVrk3hTgw3qIsGWnj5WgP3cPKV2As7Q7FcHPmirh041bpSEI1FjfOp8zQUQlqqWLIOiFl6mYlbY6xHgvHzjiisNXhxJXfM9P5hVJneFhAmreHHwiW9dht0LmS1suwwALkmbgc892khi4qzCbtWcn7b/UzNeOmjLdSunQChvsCvv4aVnImVkvXDxmqODnJ5Ozad7Ysf28G3222fFPnVbu5zS8h/zmtSqcgHCBSP0DNx8m5ocHqh7UW7XpYjOKEMGpio/3T3GP/yogtNAdHKeJkF/iyzLYpe5tteAYgO0nLSmG+qmzk=
 install:
+- if [ "$TRAVIS_SECURE_ENV_VARS" = "true" ]; then echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin; else echo "no docker credentials to log in, watch for the rate-limit"; fi
 - git clone --single-branch https://github.com/Kong/kong-pongo ../kong-pongo
 - "../kong-pongo/pongo.sh up"
 - "../kong-pongo/pongo.sh build"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
 - test rockspec; `luarocks install kong-plugin-aws-lambda`
 
 
+## unreleased
+
+- fix: handle multivalueheaders [#59](https://github.com/Kong/kong-plugin-aws-lambda/pull/59)
+
 ## aws-lambda 3.5.4 22-Mar-2021
 
 - tests: just fix the test suite so that it works with kong repo too

--- a/kong/plugins/aws-lambda/handler.lua
+++ b/kong/plugins/aws-lambda/handler.lua
@@ -101,6 +101,13 @@ local function extract_proxy_response(content)
     body = ngx_decode_base64(body)
   end
 
+  local multiValueHeaders = serialized_content.multiValueHeaders
+  if multiValueHeaders then
+    for header, values in pairs(multiValueHeaders) do
+      headers[header] = values
+    end
+  end
+
   headers["Content-Length"] = #body
 
   return {

--- a/spec/fixtures/aws-lambda.lua
+++ b/spec/fixtures/aws-lambda.lua
@@ -42,6 +42,9 @@ local fixtures = {
                     elseif string.match(ngx.var.uri, "functionWithBase64EncodedResponse") then
                       ngx.say("{\"statusCode\": 200, \"body\": \"dGVzdA==\", \"isBase64Encoded\": true}")
 
+                    elseif string.match(ngx.var.uri, "functionWithMultiValueHeadersResponse") then
+                      ngx.say("{\"statusCode\": 200, \"headers\": { \"Age\": \"3600\"}, \"multiValueHeaders\": {\"Access-Control-Allow-Origin\": [\"site1.com\", \"site2.com\"]}}")
+
                     elseif type(res) == 'string' then
                       ngx.header["Content-Length"] = #res + 1
                       ngx.say(res)

--- a/spec/plugins/aws-lambda/99-access_spec.lua
+++ b/spec/plugins/aws-lambda/99-access_spec.lua
@@ -111,6 +111,12 @@ for _, strategy in helpers.each_strategy() do
         service     = null,
       }
 
+      local route17 = bp.routes:insert {
+        hosts       = { "lambda17.com" },
+        protocols   = { "http", "https" },
+        service     = null,
+      }
+
       bp.plugins:insert {
         name     = "aws-lambda",
         route    = { id = route1.id },
@@ -329,6 +335,19 @@ for _, strategy in helpers.each_strategy() do
           aws_secret           = "mock-secret",
           aws_region           = "us-east-1",
           function_name        = "functionWithBase64EncodedResponse",
+          is_proxy_integration = true,
+        }
+      }
+
+      bp.plugins:insert {
+        name     = "aws-lambda",
+        route    = { id = route17.id },
+        config                 = {
+          port                 = 10001,
+          aws_key              = "mock-key",
+          aws_secret           = "mock-secret",
+          aws_region           = "us-east-1",
+          function_name        = "functionWithMultiValueHeadersResponse",
           is_proxy_integration = true,
         }
       }
@@ -897,6 +916,18 @@ for _, strategy in helpers.each_strategy() do
         })
         assert.res_status(200, res)
         assert.equal("test", res:read_body())
+      end)
+      it("returns multivalueheaders response from a Lambda function", function()
+        local res = assert(proxy_client:send {
+          method  = "GET",
+          path    = "/get?key1=some_value1&key2=some_value2&key3=some_value3",
+          headers = {
+            ["Host"] = "lambda17.com"
+          }
+        })
+        assert.res_status(200, res)
+        assert.is_string(res.headers.age)
+        assert.is_array(res.headers["Access-Control-Allow-Origin"])
       end)
     end)
   end)


### PR DESCRIPTION
Ensure the `multiValueHeaders` field is handled in AWS Lambda proxy
integration responses.

Fix #53.