### PR TITLE
fix(v4) sign AWS requests only

### DIFF
--- a/spec/plugins/aws-lambda/99-access_spec.lua
+++ b/spec/plugins/aws-lambda/99-access_spec.lua
@@ -373,7 +373,7 @@ for _, strategy in helpers.each_strategy() do
 
       fixtures.dns_mock:A({
         name = "lambda18.test",
-        address = "127.0.0.1",
+        address = helpers.mock_upstream_host,
       })
 
       assert(helpers.start_kong({


### PR DESCRIPTION
Do not sign requests that are not for AWS Lambda, e.g. when using a CI server.

Fixes: #60 